### PR TITLE
Get version string programatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,11 @@ import os
 
 from setuptools import setup, find_packages
 
-import faampy
 
-here = os.path.abspath(os.path.dirname(__file__))
+HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the README file
-with open(os.path.join(here, 'README.rst')) as f:
+with open(os.path.join(HERE, 'README.rst')) as f:
     long_description = f.read()
 
 with open('requirements.txt') as f:
@@ -19,8 +18,20 @@ datafiles = [(d, [os.path.join(d, f) for f in files])
     for d, folders, files in os.walk(datadir)]
 
 
+def get_faampy_version():
+    version = None
+    initpath = os.path.join(HERE, 'faampy', '__init__.py')
+    with open(initpath) as fd:
+        for line in fd:
+            if line.startswith('__version__'):
+                _, version = line.split('=')
+                version = version.strip()[1:-1]  # Remove quotation characters
+                break
+    return version
+
+
 setup(name = "faampy",
-      version = faampy.__version__,
+      version = get_faampy_version(),
       description = "python module for dealing with FAAM data",
       author = "Axel Wellpott",
       author_email = "axel dot wellpott at faam dot ac dot uk",


### PR DESCRIPTION
One small thing with faampy that might make life difficult when installing with conda is that `setup.py` requires `faampy` (to get the version string), which will set up circular dependencies when installing somewhere new. This PR proposes a different approach to getting the version string (which is gently copied from how Iris goes about this).